### PR TITLE
Support incremental models in dbt-watsonx-spark

### DIFF
--- a/dbt/adapters/watsonx_spark/impl.py
+++ b/dbt/adapters/watsonx_spark/impl.py
@@ -253,7 +253,7 @@ class SparkAdapter(SQLAdapter):
             if f"Database '{schema_relation}' not found" in errmsg:
                 return []
             # Iceberg compute engine behavior: show table
-            elif (
+            if (
                 "SHOW TABLE EXTENDED is not supported for v2 tables" in errmsg
                 or 'Invalid value from "show tables extended' in errmsg
                 or "Failed to list all tables under namespace" in errmsg

--- a/dbt/adapters/watsonx_spark/impl.py
+++ b/dbt/adapters/watsonx_spark/impl.py
@@ -263,6 +263,7 @@ class SparkAdapter(SQLAdapter):
             elif (
                 "SHOW TABLE EXTENDED is not supported for v2 tables" in errmsg
                 or 'Invalid value from "show tables extended' in errmsg
+                or "Failed to list all tables under namespace" in errmsg
             ):
                 # this happens with spark-iceberg with v2 iceberg tables
                 # https://issues.apache.org/jira/browse/SPARK-33393

--- a/dbt/adapters/watsonx_spark/impl.py
+++ b/dbt/adapters/watsonx_spark/impl.py
@@ -70,7 +70,7 @@ TABLE_OR_VIEW_NOT_FOUND_MESSAGES = (
     "Table or view not found",
     "NoSuchTableException",
 )
-
+HEADER_KEYS = ("Type:", "Provider:", "Location:", "Owner:", "Statistics:")
 
 @dataclass
 class SparkConfig(AdapterConfig):
@@ -166,7 +166,14 @@ class SparkAdapter(SQLAdapter):
     def _get_relation_information(self, row: agate.Row) -> RelationInfo:
         """relation info was fetched with SHOW TABLES EXTENDED"""
         try:
+            
             _schema, name, _, information = row
+
+            print("row",row.__dict__)
+            print("_schema",_schema)
+            print("name",name)
+            print("_",_)
+            print("information",information)
         except ValueError:
             raise DbtRuntimeError(
                 f'Invalid value from "show tables extended ...", got {len(row)} values, expected 4'
@@ -208,6 +215,7 @@ class SparkAdapter(SQLAdapter):
         """Aggregate relations with format metadata included."""
         relations = []
         for row in row_list:
+            print("row",row.__dict__)
             _schema, name, information = relation_info_func(row)
 
             rel_type: RelationType = (
@@ -235,10 +243,13 @@ class SparkAdapter(SQLAdapter):
         try different methods to fetch relation information."""
 
         kwargs = {"schema_relation": schema_relation}
-
+        # self.execute_macro("show_information", kwargs=kwargs)
         try:
             # Default compute engine behavior: show tables extended
             show_table_extended_rows = self.execute_macro(LIST_RELATIONS_MACRO_NAME, kwargs=kwargs)
+            # self.to_agate_table(show_table_extended_rows)
+            show_table_extended_rows = self.to_agate_table(show_table_extended_rows)
+            print("show_table_extended_rows: ",show_table_extended_rows[0]["information"])
             return self._build_spark_relation_list(
                 row_list=show_table_extended_rows,
                 relation_info_func=self._get_relation_information,
@@ -248,7 +259,10 @@ class SparkAdapter(SQLAdapter):
             if f"Database '{schema_relation}' not found" in errmsg:
                 return []
             # Iceberg compute engine behavior: show table
-            elif "SHOW TABLE EXTENDED is not supported for v2 tables" in errmsg:
+            elif (
+                "SHOW TABLE EXTENDED is not supported for v2 tables" in errmsg
+                or 'Invalid value from "show tables extended' in errmsg
+            ):
                 # this happens with spark-iceberg with v2 iceberg tables
                 # https://issues.apache.org/jira/browse/SPARK-33393
                 try:
@@ -504,6 +518,48 @@ class SparkAdapter(SQLAdapter):
 
         exists = True if schema in [row[0] for row in results] else False
         return exists
+
+    def to_agate_table(self,rows_list):
+        fixed = []
+        for db, name, is_temp, info in rows_list:
+            # drop catalog if present: "reema_iceberg.incremental_schema_1" -> "incremental_schema_1"
+            schema = db.split(".", 1)[-1]
+            fixed.append([schema, name, bool(is_temp), self.normalize_information(info)])
+        return agate.Table(
+            fixed,
+            column_names=["database", "tableName", "isTemporary", "information"]
+        )
+    
+    def normalize_information(self,info: str) -> str:
+        """Move header keys out of the schema block; keep proper EXTENDED shape."""
+        lines = [ln.strip() for ln in info.splitlines() if ln.strip()]
+        header, schema_lines = [], []
+        in_schema = False
+
+        for ln in lines:
+            if ln.startswith("Schema:"):
+                in_schema = True
+                continue
+            if in_schema:
+                # Lines like "|-- col: type (nullable = true)"
+                m = re.match(r"^\|--\s+(.*)$", ln)
+                if m:
+                    raw = m.group(1)
+                    if any(raw.startswith(k) for k in HEADER_KEYS):
+                        # turn "|-- Type: MANAGED (nullable = true)" -> "Type: MANAGED"
+                        k, v = raw.split(":", 1)
+                        header.append(f"{k.strip()}: {v.split('(nullable',1)[0].strip()}")
+                    else:
+                        schema_lines.append(f" |-- {raw}")
+                continue
+            # Some DESCRIBE variants list header lines before "Schema:"
+            if any(ln.startswith(k) for k in HEADER_KEYS):
+                header.append(ln)
+            # ignore other pre-schema noise
+
+        # Compose canonical blob
+        return "\n".join(header + ["Schema: root"] + schema_lines)
+    
 
     def get_rows_different_sql(
         self,

--- a/dbt/adapters/watsonx_spark/impl.py
+++ b/dbt/adapters/watsonx_spark/impl.py
@@ -169,11 +169,6 @@ class SparkAdapter(SQLAdapter):
             
             _schema, name, _, information = row
 
-            print("row",row.__dict__)
-            print("_schema",_schema)
-            print("name",name)
-            print("_",_)
-            print("information",information)
         except ValueError:
             raise DbtRuntimeError(
                 f'Invalid value from "show tables extended ...", got {len(row)} values, expected 4'
@@ -215,7 +210,6 @@ class SparkAdapter(SQLAdapter):
         """Aggregate relations with format metadata included."""
         relations = []
         for row in row_list:
-            print("row",row.__dict__)
             _schema, name, information = relation_info_func(row)
 
             rel_type: RelationType = (
@@ -243,7 +237,6 @@ class SparkAdapter(SQLAdapter):
         try different methods to fetch relation information."""
 
         kwargs = {"schema_relation": schema_relation}
-        # self.execute_macro("show_information", kwargs=kwargs)
         try:
             show_table_extended_rows = self.execute_macro(
                 LIST_RELATIONS_MACRO_NAME, kwargs=kwargs
@@ -527,7 +520,7 @@ class SparkAdapter(SQLAdapter):
     def to_agate_table(self,rows_list):
         fixed = []
         for db, name, is_temp, info in rows_list:
-            # drop catalog if present: "reema_iceberg.incremental_schema_1" -> "incremental_schema_1"
+            # drop catalog if present: "catalog.schema" -> "schema"
             schema = db.split(".", 1)[-1]
             fixed.append([schema, name, bool(is_temp), self.normalize_information(info)])
         return agate.Table(
@@ -560,7 +553,6 @@ class SparkAdapter(SQLAdapter):
             # Some DESCRIBE variants list header lines before "Schema:"
             if any(ln.startswith(k) for k in HEADER_KEYS):
                 header.append(ln)
-            # ignore other pre-schema noise
 
         # Compose canonical blob
         return "\n".join(header + ["Schema: root"] + schema_lines)

--- a/dbt/adapters/watsonx_spark/impl.py
+++ b/dbt/adapters/watsonx_spark/impl.py
@@ -245,15 +245,16 @@ class SparkAdapter(SQLAdapter):
         kwargs = {"schema_relation": schema_relation}
         # self.execute_macro("show_information", kwargs=kwargs)
         try:
-            # Default compute engine behavior: show tables extended
-            show_table_extended_rows = self.execute_macro(LIST_RELATIONS_MACRO_NAME, kwargs=kwargs)
-            # self.to_agate_table(show_table_extended_rows)
-            show_table_extended_rows = self.to_agate_table(show_table_extended_rows)
-            print("show_table_extended_rows: ",show_table_extended_rows[0]["information"])
-            return self._build_spark_relation_list(
+            show_table_extended_rows = self.execute_macro(
+                LIST_RELATIONS_MACRO_NAME, kwargs=kwargs
+            )
+            rels = self._build_spark_relation_list(
                 row_list=show_table_extended_rows,
                 relation_info_func=self._get_relation_information,
             )
+            if "." in schema_relation.schema:
+                rels = [r.incorporate(path={"schema": schema_relation.schema}) for r in rels]
+            return rels
         except DbtRuntimeError as e:
             errmsg = getattr(e, "msg", "")
             if f"Database '{schema_relation}' not found" in errmsg:
@@ -270,10 +271,13 @@ class SparkAdapter(SQLAdapter):
                     show_table_rows = self.execute_macro(
                         LIST_RELATIONS_SHOW_TABLES_MACRO_NAME, kwargs=kwargs
                     )
-                    return self._build_spark_relation_list(
+                    rels = self._build_spark_relation_list(
                         row_list=show_table_rows,
                         relation_info_func=self._get_relation_information_using_describe,
                     )
+                    if "." in schema_relation.schema:
+                        rels = [r.incorporate(path={"schema": schema_relation.schema}) for r in rels]
+                    return rels
                 except DbtRuntimeError as e:
                     description = "Error while retrieving information about"
                     logger.debug(f"{description} {schema_relation}: {e.msg}")

--- a/dbt/adapters/watsonx_spark/impl.py
+++ b/dbt/adapters/watsonx_spark/impl.py
@@ -249,7 +249,7 @@ class SparkAdapter(SQLAdapter):
                 rels = [r.incorporate(path={"schema": schema_relation.schema}) for r in rels]
             return rels
         except DbtRuntimeError as e:
-            errmsg = getattr(e, "msg", "")
+            errmsg = getattr(e, "msg", "").lower()
             if f"Database '{schema_relation}' not found" in errmsg:
                 return []
             # Iceberg compute engine behavior: show table

--- a/dbt/adapters/watsonx_spark/impl.py
+++ b/dbt/adapters/watsonx_spark/impl.py
@@ -250,14 +250,15 @@ class SparkAdapter(SQLAdapter):
             return rels
         except DbtRuntimeError as e:
             errmsg = getattr(e, "msg", "").lower()
-            if f"Database '{schema_relation}' not found" in errmsg:
+            if f"database '{schema_relation}' not found" in errmsg:
                 return []
             # Iceberg compute engine behavior: show table
             if (
-                "SHOW TABLE EXTENDED is not supported for v2 tables" in errmsg
-                or 'Invalid value from "show tables extended' in errmsg
-                or "Failed to list all tables under namespace" in errmsg
-           or ("show table extended" in errmsg and "not supported" in errmsg)):
+                "show table extended is not supported for v2 tables" in errmsg
+                or 'invalid value from "show tables extended' in errmsg
+                or "failed to list all tables under namespace" in errmsg
+                or ("show table extended" in errmsg and "not supported" in errmsg)
+                ):
                 # this happens with spark-iceberg with v2 iceberg tables
                 # https://issues.apache.org/jira/browse/SPARK-33393
                 try:

--- a/dbt/adapters/watsonx_spark/impl.py
+++ b/dbt/adapters/watsonx_spark/impl.py
@@ -257,7 +257,7 @@ class SparkAdapter(SQLAdapter):
                 "SHOW TABLE EXTENDED is not supported for v2 tables" in errmsg
                 or 'Invalid value from "show tables extended' in errmsg
                 or "Failed to list all tables under namespace" in errmsg
-            ):
+           or ("show table extended" in errmsg and "not supported" in errmsg)):
                 # this happens with spark-iceberg with v2 iceberg tables
                 # https://issues.apache.org/jira/browse/SPARK-33393
                 try:

--- a/dbt/include/watsonx_spark/macros/adapters.sql
+++ b/dbt/include/watsonx_spark/macros/adapters.sql
@@ -312,15 +312,11 @@
 
 {% macro watsonx_spark__list_relations_without_caching(relation) %}
   {% call statement('list_relations_without_caching', fetch_result=True) -%}
-  {%- if config.get("file_format") == "1" %}
       show table extended in {{ relation.schema }} like '*'
-  {% else %}
-      show tables in {{ relation.schema }} like '*'
-  {% endif %}
-{% endcall %}
-
+  {% endcall %}
   {% do return(load_result('list_relations_without_caching').table) %}
 {% endmacro %}
+
 
 {% macro list_relations_show_tables_without_caching(schema_relation) %}
   {#-- Spark with iceberg tables don't work with show table extended for #}


### PR DESCRIPTION
# Summary
Enable incremental models on watsonx-spark by fixing relation listing under Hive v1 and catalogqualified schemas.

# Problem
`SHOW TABLES` on Hive v1 returns 3 columns. The adapter assumed 4, so existence checks failed and dbt used `CREATE OR REPLACE` on every run. Also, Spark returns `_schema` without catalog, which didn’t match targets like `catalog.schema`.

# What changed
- **`impl.py`**
  - Broaden fallback: on EXTENDED parse/unsupported errors, call `SHOW TABLES` and per row `DESCRIBE EXTENDED`.
  - Normalize listed relations’ `schema` to the caller’s catalog qualified schema when provided.
- **`adapters.sql`**
  - Simplify `watsonx_spark__list_relations_without_caching` to call `SHOW TABLE EXTENDED`; rely on adapter fallback for Hive v1.

# Behavior
- Try `SHOW TABLE EXTENDED` first.
- If unsupported or parsed as 3 cols, use `SHOW TABLES` + `DESCRIBE EXTENDED` per table.
- Relation schemas are rewritten to `catalog.schema` when the caller used a qualified schema.

# Validation
- Ran the same model twice.
  - Run 1: `CREATE OR REPLACE TABLE`.
  - Run 2: `SHOW TABLE EXTENDED` → `DESCRIBE EXTENDED` → `INSERT INTO reema_catalog.incremntal_schema.inct`.
  - No `CREATE OR REPLACE` on run 2.
  - [Output Logs.zip](https://github.com/user-attachments/files/22408468/Output.Logs.zip)

# Issue:
https://github.ibm.com/lakehouse/tracker/issues/39274